### PR TITLE
fix: prevent uncaught exception when unable to retrieve figure from API

### DIFF
--- a/src/Controller/OchaKeyFiguresController.php
+++ b/src/Controller/OchaKeyFiguresController.php
@@ -421,23 +421,21 @@ class OchaKeyFiguresController extends ControllerBase {
         $fullUrl,
         ['headers' => $headers],
       );
+
+      $body = $response->getBody() . '';
+      $results = json_decode($body, TRUE, 512, JSON_THROW_ON_ERROR);
     }
     catch (RequestException $exception) {
       $this->getLogger('ocha_key_figures_fts_figures')->error('Fetching data from @url failed with @message', [
         '@url' => $fullUrl,
         '@message' => $exception->getMessage(),
       ]);
-
-      if ($exception->getCode() === 404) {
-        throw new NotFoundHttpException();
-      }
-      else {
-        throw $exception;
-      }
+      $results = [];
     }
 
-    $body = $response->getBody() . '';
-    $results = json_decode($body, TRUE);
+    if (!is_array($results)) {
+      $results = [];
+    }
 
     // Cache data.
     if ($use_cache) {

--- a/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
+++ b/src/Plugin/Field/FieldFormatter/KeyFigureCondensed.php
@@ -93,14 +93,19 @@ class KeyFigureCondensed extends KeyFigureBase {
         $unit = $item->getFigureUnit();
 
         if ($item->getFigureProvider() != 'manual') {
-          $data = $this->ochaKeyFiguresApiClient->query($item->getFigureProvider(), $item->getFigureId());
-          $value = $data['value'];
-          $unit = $data['unit'] ?? '';
+          $data = $this->ochaKeyFiguresApiClient->query($item->getFigureProvider(), strtolower($item->getFigureId()));
+          if (isset($data['value'], $data['value_type'])) {
+            $value = $data['value'];
+            $unit = $data['unit'] ?? '';
 
-          if ($data['value_type'] == 'percentage') {
-            if ($percentage_formatted == 'no') {
-              $value /= 100;
+            if ($data['value_type'] == 'percentage') {
+              if ($percentage_formatted == 'no') {
+                $value /= 100;
+              }
             }
+          }
+          else {
+            $value = (string) $this->t('N/A');
           }
         }
 

--- a/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
+++ b/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
@@ -101,16 +101,21 @@ class KeyFigurePresenceCondensed extends KeyFigureBase {
 
         $data = $this->ochaKeyFiguresApiClient->getgetOchaPresenceFigureByFigureId($item->getFigureProvider(), $item->getFigureOchaPresence(), $item->getFigureYear(), $item->getFigureId());
         $data = reset($data);
-        $cache_tags = $data['cache_tags'];
-        unset($data['cache_tags']);
+        if (isset($data['value'], $data['value_type'])) {
+          $cache_tags = $data['cache_tags'];
+          unset($data['cache_tags']);
 
-        $value = $data['value'];
-        $unit = $data['unit'] ?? '';
+          $value = $data['value'];
+          $unit = $data['unit'] ?? '';
 
-        if ($data['value_type'] == 'percentage') {
-          if ($percentage_formatted == 'no') {
-            $value /= 100;
+          if ($data['value_type'] == 'percentage') {
+            if ($percentage_formatted == 'no') {
+              $value /= 100;
+            }
           }
+        }
+        else {
+          $value = (string) $this->t('N/A');
         }
 
         if (isset($label, $value)) {


### PR DESCRIPTION
Refs: OHA-51

This PR removes the exception thrown by the key figures controller getData as it is not caught by the formatters or widgets and so is passed on and can result for example in page not found when a figure on a page cannot be retrieved from the API.

It also adds some minimal validity check for the figure value in the formatters and show `N/A` if not valid.

Note: https://github.com/UN-OCHA/ocha_key_figures/pull/6 should be applied as well.