### PR TITLE
[OHA-55] Option to restrict providers and figure IDs

### DIFF
--- a/config/schema/ocha_key_figures.schema.yml
+++ b/config/schema/ocha_key_figures.schema.yml
@@ -17,3 +17,138 @@ ocha_key_figures.settings:
     max_age:
       type: integer
       label: 'Max age for cache'
+
+# Field types.
+field.field_settings.key_figure:
+  type: mapping
+  mapping:
+    label:
+      type: string
+      label: 'Figure label'
+    value:
+      type: string
+      label: 'Figure value'
+    unit:
+      type: string
+      label: 'Figure unit'
+    provider:
+      type: string
+      label: 'Figure provider'
+    id:
+      type: string
+      label: 'Figure ID'
+    country:
+      type: string
+      label: 'Figure country'
+    year:
+      type: integer
+      label: 'Figure year'
+
+field.field_settings.key_figure_presence:
+  type: mapping
+  mapping:
+    label:
+      type: string
+      label: 'Figure label'
+    value:
+      type: string
+      label: 'Figure value'
+    unit:
+      type: string
+      label: 'Figure unit'
+    provider:
+      type: string
+      label: 'Figure provider'
+    id:
+      type: string
+      label: 'Figure ID'
+    ochapresence:
+      type: string
+      label: 'Figure ocha presence'
+    year:
+      type: integer
+      label: 'Figure year'
+
+# Field formatters.
+field.formatter.settings.key_figure:
+  type: mapping
+  label: 'Key Figure formatter settings'
+  mapping:
+    format:
+      type: string
+      label: 'Number format'
+    precision:
+      type: integer
+      label: 'Number of digits after the decimal'
+    percentage:
+      type: boolean
+      label: 'Use currency symbol'
+    currency_symbol:
+      type: boolean
+      label: 'Format percentages'
+
+field.formatter.settings.key_figure_extended:
+  type: mapping
+  label: 'Key Figure formatter settings'
+  mapping:
+    format:
+      type: string
+      label: 'Number format'
+    precision:
+      type: integer
+      label: 'Number of digits after the decimal'
+    percentage:
+      type: boolean
+      label: 'Use currency symbol'
+    currency_symbol:
+      type: boolean
+      label: 'Format percentages'
+    display_sparklines:
+      type: boolean
+      label: 'Display sparklines'
+    output_json_ld:
+      type: boolean
+      label: 'Output Json Ld'
+
+field.formatter.settings.key_figure_presence:
+  type: mapping
+  label: 'Key Figure formatter settings'
+  mapping:
+    format:
+      type: string
+      label: 'Number format'
+    precision:
+      type: integer
+      label: 'Number of digits after the decimal'
+    percentage:
+      type: boolean
+      label: 'Use currency symbol'
+    currency_symbol:
+      type: boolean
+      label: 'Format percentages'
+
+# Field widgets.
+field.formatter.settings.key_figure:
+  type: mapping
+  label: 'Key Figure formatter settings'
+  mapping:
+    allow_manual:
+      type: boolean
+      label: 'Allow manual numbers'
+    allowed_providers:
+      type: string
+      label: 'Allowed providers'
+    allowed_figure_ids:
+      type: string
+      label: 'Allowed figure IDs'
+
+field.formatter.settings.key_figure_presence:
+  type: mapping
+  label: 'Key Figure formatter settings'
+  mapping:
+    allowed_providers:
+      type: string
+      label: 'Allowed providers'
+    allowed_figure_ids:
+      type: string
+      label: 'Allowed figure IDs'

--- a/src/Controller/OchaKeyFiguresController.php
+++ b/src/Controller/OchaKeyFiguresController.php
@@ -963,7 +963,7 @@ class OchaKeyFiguresController extends ControllerBase {
   /**
    * Get figure by figure id.
    */
-  public function getgetOchaPresenceFigureByFigureId(string $provider, string $ocha_presence_id, string $year, string $figure_id) : array {
+  public function getOchaPresenceFigureByFigureId(string $provider, string $ocha_presence_id, string $year, string $figure_id) : array {
     $prefix = $this->getPrefix($provider);
     if ($year == 2) {
       $year = date('Y');

--- a/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
+++ b/src/Plugin/Field/FieldFormatter/KeyFigurePresenceCondensed.php
@@ -99,7 +99,7 @@ class KeyFigurePresenceCondensed extends KeyFigureBase {
         $value = $item->getFigureValue();
         $unit = $item->getFigureUnit();
 
-        $data = $this->ochaKeyFiguresApiClient->getgetOchaPresenceFigureByFigureId($item->getFigureProvider(), $item->getFigureOchaPresence(), $item->getFigureYear(), $item->getFigureId());
+        $data = $this->ochaKeyFiguresApiClient->getOchaPresenceFigureByFigureId($item->getFigureProvider(), $item->getFigureOchaPresence(), $item->getFigureYear(), $item->getFigureId());
         $data = reset($data);
         if (isset($data['value'], $data['value_type'])) {
           $cache_tags = $data['cache_tags'];

--- a/src/Plugin/Field/FieldWidget/KeyFigure.php
+++ b/src/Plugin/Field/FieldWidget/KeyFigure.php
@@ -109,8 +109,8 @@ class KeyFigure extends WidgetBase {
   public static function defaultSettings() {
     return [
       'allow_manual' => 'yes',
-      'allowed_providers' => [],
-      'allowed_figure_ids' => [],
+      'allowed_providers' => '',
+      'allowed_figure_ids' => '',
     ] + parent::defaultSettings();
   }
 

--- a/src/Plugin/Field/FieldWidget/KeyFigurePresence.php
+++ b/src/Plugin/Field/FieldWidget/KeyFigurePresence.php
@@ -108,8 +108,8 @@ class KeyFigurePresence extends WidgetBase {
    */
   public static function defaultSettings() {
     return [
-      'allowed_providers' => [],
-      'allowed_figure_ids' => [],
+      'allowed_providers' => '',
+      'allowed_figure_ids' => '',
     ] + parent::defaultSettings();
   }
 


### PR DESCRIPTION
Refs: OHA-55

This PR adds 2 settings to the KeyFigure and KeyFigurePresence field widgets to be able to restrict the list of providers and figure IDs.

For example for UNO D10, the fields for the donors paragraph limit the allowed providers to CBPF, FTS and OCT and figures to `top-donors`, `earmarked-donors` and `unearmarked-donors` making it much easier for editors to select the proper figures.

<img width="725" alt="Screenshot 2023-06-22 at 14 20 39" src="https://github.com/UN-OCHA/ocha_key_figures/assets/696348/684024fd-2b90-4cc9-a965-7dda09c66e1e">

This just adds new settings and should not have any impact on existing sites (no restriction).

*Note: this is based of the branch of https://github.com/UN-OCHA/ocha_key_figures/pull/9*