### PR TITLE
fix: display 0 as 0 not - and display non numeric values as -

### DIFF
--- a/src/Helpers/NumberFormatter.php
+++ b/src/Helpers/NumberFormatter.php
@@ -316,7 +316,7 @@ class NumberFormatter {
    * @see http://st.unicode.org/cldr-apps/v#/fr/Compact_Decimal_Formatting
    */
   public static function formatNumberCompact($number, $langcode, $type = 'long', $precision = 2, $use_gho_specifics = FALSE) {
-    if ($number <= 0) {
+    if (!is_numeric($number) || $number < 0) {
       return '-';
     }
     elseif ($number < 1000) {


### PR DESCRIPTION
Refs: UNO-708

This ensures `0` are displayed as `0` not `-` and that non numeric values are displayed as `-`.

**Note** the display of `0` as `-` was a requirement from GHO 2020 from which the NumberFormatter was extracted.