### PR TITLE
fix: adjust for typeError

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.3
           tools: composer
         env:
           fail-fast: true

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           tools: composer
         env:
           fail-fast: true

--- a/ocha_key_figures.info.yml
+++ b/ocha_key_figures.info.yml
@@ -1,7 +1,7 @@
 name: 'OCHA Key Figures'
 description: 'OCHA Key Figures'
 type: module
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^11
 dependencies:
   - core:options
 configure: ocha_key_figures.ocha_presences

--- a/src/Controller/WebhookController.php
+++ b/src/Controller/WebhookController.php
@@ -2,14 +2,13 @@
 
 namespace Drupal\ocha_key_figures\Controller;
 
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\ocha_key_figures\Controller\OchaKeyFiguresController;
 use Drupal\ocha_key_figures\Event\KeyFiguresUpdated;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -43,7 +42,7 @@ class WebhookController extends ControllerBase {
   /**
    * The event dispatcher.
    *
-   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   * @var \Symfony\Component\EventDispatcher\EventDispatcher
    */
   protected $eventDispatcher;
 
@@ -61,9 +60,9 @@ class WebhookController extends ControllerBase {
     OchaKeyFiguresController $ocha_key_figure_api_client,
     EntityTypeManagerInterface $entity_type_manager,
     EntityFieldManager $entity_field_manager,
-    ContainerAwareEventDispatcher $event_dispatcher,
+    EventDispatcher $event_dispatcher,
     LoggerChannelFactoryInterface $logger_factory,
-    ) {
+  ) {
     $this->ochaKeyFiguresApiClient = $ocha_key_figure_api_client;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;


### PR DESCRIPTION
After upgrading to D11, got a TypeError message when importing config:
```
TypeError: Drupal\ocha_key_figures\Controller\WebhookController::__construct(): Argument #4 ($event_dispatcher) must be of type Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher, Symfony\Component\EventDispatcher\EventDispatcher given, called in /srv/www/html/core/lib/Drupal/Component/DependencyInjection/Container.php on line 259 in Drupal\ocha_key_figures\Controller\WebhookController->__construct() (line 60 of /srv/www/html/modules/contrib/ocha_key_figures/src/Controller/WebhookController.php).
```
