### PR TITLE
fix(bug): Avoid a deprecation warning by never comparing floats with integers.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout Code
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Composer Validate
         id: validate

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -28,15 +28,17 @@ jobs:
 
       - name: Checkout Code
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: web/modules/ocha_key_figures
 
       - name: Install test dependencies
+        id: install
         run: |
-          composer --no-interaction --no-progress require \
-            phpspec/prophecy-phpunit phpunit/phpunit behat/mink phpcompatibility/php-compatibility symfony/phpunit-bridge
+          composer --no-interaction --no-progress -W require \
+              phpspec/prophecy-phpunit phpunit/phpunit:^11.5 behat/mink phpcompatibility/php-compatibility symfony/phpunit-bridge
 
       - name: Run unit tests
+        id: phpunit
         run: |
           ./vendor/bin/phpunit --configuration web/core/phpunit.xml.dist web/modules/ocha_key_figures/tests

--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,14 @@
     "type": "drupal-module",
     "require": {
         "symfony/intl": "^6.2"
+    },
+    "require-dev": {
+        "phpspec/prophecy-phpunit": "^2.5",
+        "phpunit/phpunit": "^11.5",
+        "behat/mink": "^1.13",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "symfony/phpunit-bridge": "^8.1",
+        "symfony/browser-kit": "^8.1",
+        "symfony/css-selector": "^8.1"
     }
 }

--- a/src/Helpers/NumberFormatter.php
+++ b/src/Helpers/NumberFormatter.php
@@ -473,6 +473,8 @@ class NumberFormatter {
     // The rules here are based on the rules and compact decimal values for
     // the languages, adapted to our use case where we provide a number between
     // 0 and 1000.
+    // We use the integer digits of $number for our mod comparison to avoid an
+    // implicit conversion deprecation warning when dealing with a float.
     switch ($langcode) {
       // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/ar.html
       case 'ar':
@@ -485,10 +487,10 @@ class NumberFormatter {
         elseif ($n === 2) {
           return 'two';
         }
-        elseif (($n % 100 >= 3) && ($n % 100 <= 10)) {
+        elseif (($i % 100 >= 3) && ($i % 100 <= 10)) {
           return 'few';
         }
-        elseif (($n % 100 >= 11) && ($n % 100 <= 99)) {
+        elseif (($i % 100 >= 11) && ($i % 100 <= 99)) {
           return 'many';
         }
         return 'other';


### PR DESCRIPTION
Because we use the modulo and >= we can simply use the integer digits and not affect the outcome.

Refs: UNO-903